### PR TITLE
Inequality join

### DIFF
--- a/src/simpledb/index/planner/NestedLoopsJoinPlan.java
+++ b/src/simpledb/index/planner/NestedLoopsJoinPlan.java
@@ -8,7 +8,6 @@ import simpledb.record.Schema;
 
 public class NestedLoopsJoinPlan implements Plan {
    private Plan p1, p2;
-   private String fldname1, fldname2;
    private Predicate joinpred;
    private Schema sch = new Schema();
 
@@ -17,15 +16,11 @@ public class NestedLoopsJoinPlan implements Plan {
     * 
     * @param p1       the left-hand plan
     * @param p2       the right-hand plan
-    * @param fldname1 the LHS join field
-    * @param fldname2 the RHS join field
     * @param joinpred the join predicate involved in this table
     */
-   public NestedLoopsJoinPlan(Plan p1, Plan p2, String fldname1, String fldname2, Predicate joinpred) {
+   public NestedLoopsJoinPlan(Plan p1, Plan p2, Predicate joinpred) {
       this.p1 = p1;
       this.p2 = p2;
-      this.fldname1 = fldname1;
-      this.fldname2 = fldname2;
       this.joinpred = joinpred;
       sch.addAll(p1.schema());
       sch.addAll(p2.schema());
@@ -39,7 +34,7 @@ public class NestedLoopsJoinPlan implements Plan {
    public Scan open() {
       Scan s1 = p1.open();
       Scan s2 = p2.open();
-      return new NestedLoopsJoinScan(s1, s2, fldname1, fldname2, joinpred);
+      return new NestedLoopsJoinScan(s1, s2, joinpred);
    }
 
    /**

--- a/src/simpledb/index/planner/NestedLoopsJoinPlan.java
+++ b/src/simpledb/index/planner/NestedLoopsJoinPlan.java
@@ -35,6 +35,7 @@ public class NestedLoopsJoinPlan implements Plan {
    public Scan open() {
       Scan s1 = p1.open();
       Scan s2 = p2.open();
+      // TODO: support joinpred field
       return new NestedLoopsJoinScan(s1, s2, fldname1, fldname2);
    }
 

--- a/src/simpledb/index/planner/NestedLoopsJoinPlan.java
+++ b/src/simpledb/index/planner/NestedLoopsJoinPlan.java
@@ -2,12 +2,14 @@ package simpledb.index.planner;
 
 import simpledb.index.query.NestedLoopsJoinScan;
 import simpledb.plan.Plan;
+import simpledb.query.Predicate;
 import simpledb.query.Scan;
 import simpledb.record.Schema;
 
 public class NestedLoopsJoinPlan implements Plan {
    private Plan p1, p2;
    private String fldname1, fldname2;
+   private Predicate joinpred;
    private Schema sch = new Schema();
 
    /**
@@ -17,12 +19,14 @@ public class NestedLoopsJoinPlan implements Plan {
     * @param p2       the right-hand plan
     * @param fldname1 the LHS join field
     * @param fldname2 the RHS join field
+    * @param joinpred the join predicate involved in this table
     */
-   public NestedLoopsJoinPlan(Plan p1, Plan p2, String fldname1, String fldname2) {
+   public NestedLoopsJoinPlan(Plan p1, Plan p2, String fldname1, String fldname2, Predicate joinpred) {
       this.p1 = p1;
       this.p2 = p2;
       this.fldname1 = fldname1;
       this.fldname2 = fldname2;
+      this.joinpred = joinpred;
       sch.addAll(p1.schema());
       sch.addAll(p2.schema());
    }
@@ -35,8 +39,7 @@ public class NestedLoopsJoinPlan implements Plan {
    public Scan open() {
       Scan s1 = p1.open();
       Scan s2 = p2.open();
-      // TODO: support joinpred field
-      return new NestedLoopsJoinScan(s1, s2, fldname1, fldname2);
+      return new NestedLoopsJoinScan(s1, s2, fldname1, fldname2, joinpred);
    }
 
    /**

--- a/src/simpledb/index/query/NestedLoopsJoinScan.java
+++ b/src/simpledb/index/query/NestedLoopsJoinScan.java
@@ -67,6 +67,7 @@ public class NestedLoopsJoinScan implements Scan {
          while (hasmore2) {
             Constant v2 = rhs.getVal(fldname2);
 
+            // TODO: generalize to support inequality join operator
             if (joinval.compareTo(v2) == 0) {
                return true;
             }

--- a/src/simpledb/index/query/NestedLoopsJoinScan.java
+++ b/src/simpledb/index/query/NestedLoopsJoinScan.java
@@ -1,11 +1,13 @@
 package simpledb.index.query;
 
 import simpledb.query.Constant;
+import simpledb.query.Predicate;
 import simpledb.query.Scan;
 
 public class NestedLoopsJoinScan implements Scan {
    private Scan lhs, rhs;
    private String fldname1, fldname2;
+   private Predicate joinpred;
    private Constant joinval = null;
 
    /**
@@ -16,11 +18,12 @@ public class NestedLoopsJoinScan implements Scan {
     * @param fldname1 the LHS join field
     * @param fldname2 the RHS join field
     */
-   public NestedLoopsJoinScan(Scan lhs, Scan rhs, String fldname1, String fldname2) {
+   public NestedLoopsJoinScan(Scan lhs, Scan rhs, String fldname1, String fldname2, Predicate joinpred) {
       this.lhs = lhs;
       this.rhs = rhs;
       this.fldname1 = fldname1;
       this.fldname2 = fldname2;
+      this.joinpred = joinpred;
       beforeFirst();
    }
 
@@ -67,8 +70,7 @@ public class NestedLoopsJoinScan implements Scan {
          while (hasmore2) {
             Constant v2 = rhs.getVal(fldname2);
 
-            // TODO: generalize to support inequality join operator
-            if (joinval.compareTo(v2) == 0) {
+            if (joinpred.isSatisfied(lhs, rhs)) {
                return true;
             }
 

--- a/src/simpledb/opt/TablePlanner.java
+++ b/src/simpledb/opt/TablePlanner.java
@@ -100,16 +100,9 @@ class TablePlanner {
    private Plan makeBestJoinMethod(Plan current, Schema currsch, Predicate joinpred) {
       Optional<Plan> idxJoinPlan = Optional.empty();
       Optional<Plan> mergeJoinPlan = Optional.empty();
-      Optional<Plan> nestedLoopJoinPlan = Optional.empty();
 
-      for (String fldname : myschema.fields()) {
-         String outerfield = mypred.equatesWithField(fldname);
-         if (outerfield != null && currsch.hasField(outerfield)) {
-            // TODO: optimize for smaller blocksAccessed as the outer page (ie. LHS)
-            nestedLoopJoinPlan = Optional
-                  .ofNullable(new NestedLoopsJoinPlan(current, myplan, outerfield, fldname, joinpred));
-         }
-      }
+      // TODO: optimize for smaller blocksAccessed as the outer page (ie. LHS)
+      Optional<Plan> nestedLoopJoinPlan = Optional.ofNullable(new NestedLoopsJoinPlan(current, myplan, joinpred));
 
       // attempt to create idx and sort-merge join if no inequality join
       if (!joinpred.hasInequalityOpr()) {

--- a/src/simpledb/opt/TablePlanner.java
+++ b/src/simpledb/opt/TablePlanner.java
@@ -101,8 +101,10 @@ class TablePlanner {
       Optional<Plan> idxJoinPlan = Optional.empty();
       Optional<Plan> mergeJoinPlan = Optional.empty();
 
-      // TODO: optimize for smaller blocksAccessed as the outer page (ie. LHS)
-      Optional<Plan> nestedLoopJoinPlan = Optional.ofNullable(new NestedLoopsJoinPlan(current, myplan, joinpred));
+      // optimize for smaller blocksAccessed as the outer page (ie. LHS)
+      Optional<Plan> nestedLoopJoinPlan = (current.recordsOutput() <= myplan.recordsOutput())
+            ? Optional.ofNullable(new NestedLoopsJoinPlan(current, myplan, joinpred))
+            : Optional.ofNullable(new NestedLoopsJoinPlan(myplan, current, joinpred));
 
       // attempt to create idx and sort-merge join if no non-equal join condition eg.
       // "<>", "<=", "<"

--- a/src/simpledb/opt/TablePlanner.java
+++ b/src/simpledb/opt/TablePlanner.java
@@ -68,7 +68,7 @@ class TablePlanner {
       Predicate joinpred = mypred.joinSubPred(myschema, currsch);
       if (joinpred == null)
          return null;
-      Plan p = makeBestJoinMethod(current, currsch);
+      Plan p = makeBestJoinMethod(current, currsch, joinpred);
       if (p == null)
          p = makeProductJoin(current, currsch);
       return p;
@@ -97,7 +97,7 @@ class TablePlanner {
       return null;
    }
 
-   private Plan makeBestJoinMethod(Plan current, Schema currsch) {
+   private Plan makeBestJoinMethod(Plan current, Schema currsch, Predicate joinpred) {
       Optional<Plan> p1 = Optional.empty();
       Optional<Plan> p2 = Optional.empty();
       Optional<Plan> p3 = Optional.empty();
@@ -116,6 +116,7 @@ class TablePlanner {
          }
          if (outerfield != null && currsch.hasField(outerfield)) {
             // TODO: optimize for smaller blocksAccessed as the outer page (ie. LHS)
+            // TODO 2: handle inequality join
             p3 = Optional.ofNullable(new NestedLoopsJoinPlan(current, myplan, outerfield, fldname));
          }
       }

--- a/src/simpledb/opt/TablePlanner.java
+++ b/src/simpledb/opt/TablePlanner.java
@@ -104,8 +104,9 @@ class TablePlanner {
       // TODO: optimize for smaller blocksAccessed as the outer page (ie. LHS)
       Optional<Plan> nestedLoopJoinPlan = Optional.ofNullable(new NestedLoopsJoinPlan(current, myplan, joinpred));
 
-      // attempt to create idx and sort-merge join if no inequality join
-      if (!joinpred.hasInequalityOpr()) {
+      // attempt to create idx and sort-merge join if no non-equal join condition eg.
+      // "<>", "<=", "<"
+      if (!joinpred.hasNonEqualOpr()) {
          for (String fldname : indexes.keySet()) {
             String outerfield = mypred.equatesWithField(fldname);
             if (outerfield != null && currsch.hasField(outerfield)) {

--- a/src/simpledb/opt/TablePlanner.java
+++ b/src/simpledb/opt/TablePlanner.java
@@ -134,7 +134,7 @@ class TablePlanner {
       if (mergeJoinPlanCost < nestedLoopJoinPlanCost && mergeJoinPlanCost < idxJoinPlanCost) {
          System.out.println("Running sort merge");
          bestplan = mergeJoinPlan.orElse(null);
-      } else if ((nestedLoopJoinPlanCost < idxJoinPlanCost && nestedLoopJoinPlanCost < mergeJoinPlanCost)) {
+      } else if (nestedLoopJoinPlanCost < idxJoinPlanCost && nestedLoopJoinPlanCost < mergeJoinPlanCost) {
          System.out.println("Running nested loop join");
          bestplan = nestedLoopJoinPlan.orElse(null);
       } else {

--- a/src/simpledb/query/Operator.java
+++ b/src/simpledb/query/Operator.java
@@ -3,9 +3,11 @@ package simpledb.query;
 import java.util.*;
 
 public class Operator {
-  private static final HashSet<String> VALID_OPERATORS_ARR = new HashSet<>(Arrays.asList("=", "<", ">", "<=", ">=", "<>", "!="));
+  private static final HashSet<String> VALID_OPERATORS = new HashSet<>(
+      Arrays.asList("=", "<", ">", "<=", ">=", "<>", "!="));
+  private static final HashSet<String> INEQUALITY_OPERATORS = new HashSet<>(Arrays.asList("<", ">", "<=", ">="));
   private String opVal;
-  
+
   public Operator(String opVal) {
     this.opVal = opVal;
   }
@@ -14,7 +16,11 @@ public class Operator {
     return this.opVal;
   }
 
+  public boolean isInequality() {
+    return INEQUALITY_OPERATORS.contains(opVal);
+  }
+
   public static boolean isValidOpString(String opStr) {
-    return VALID_OPERATORS_ARR.contains(opStr);
+    return VALID_OPERATORS.contains(opStr);
   }
 }

--- a/src/simpledb/query/Operator.java
+++ b/src/simpledb/query/Operator.java
@@ -6,6 +6,7 @@ public class Operator {
   private static final HashSet<String> VALID_OPERATORS = new HashSet<>(
       Arrays.asList("=", "<", ">", "<=", ">=", "<>", "!="));
   private static final HashSet<String> INEQUALITY_OPERATORS = new HashSet<>(Arrays.asList("<", ">", "<=", ">="));
+  private static final HashSet<String> NOT_EQUAL_OPERATORS = new HashSet<>(Arrays.asList("<>", "!="));
   private String opVal;
 
   public Operator(String opVal) {
@@ -16,8 +17,8 @@ public class Operator {
     return this.opVal;
   }
 
-  public boolean isInequality() {
-    return INEQUALITY_OPERATORS.contains(opVal);
+  public boolean isNonEqualOpr() {
+    return NOT_EQUAL_OPERATORS.contains(opVal) || INEQUALITY_OPERATORS.contains(opVal);
   }
 
   public static boolean isValidOpString(String opStr) {

--- a/src/simpledb/query/Predicate.java
+++ b/src/simpledb/query/Predicate.java
@@ -7,8 +7,8 @@ import simpledb.record.*;
 
 /**
  * A predicate is a Boolean combination of terms.
+ * 
  * @author Edward Sciore
- *
  */
 public class Predicate {
    private List<Term> terms = new ArrayList<Term>();
@@ -20,6 +20,7 @@ public class Predicate {
 
    /**
     * Create a predicate containing a single term.
+    * 
     * @param t the term
     */
    public Predicate(Term t) {
@@ -27,8 +28,9 @@ public class Predicate {
    }
 
    /**
-    * Modifies the predicate to be the conjunction of
-    * itself and the specified predicate.
+    * Modifies the predicate to be the conjunction of itself and the specified
+    * predicate.
+    * 
     * @param pred the other predicate
     */
    public void conjoinWith(Predicate pred) {
@@ -36,8 +38,9 @@ public class Predicate {
    }
 
    /**
-    * Returns true if the predicate evaluates to true
-    * with respect to the specified scan.
+    * Returns true if the predicate evaluates to true with respect to the specified
+    * scan.
+    * 
     * @param s the scan
     * @return true if the predicate is true in the scan
     */
@@ -48,14 +51,38 @@ public class Predicate {
       return true;
    }
 
-   /** 
-    * Calculate the extent to which selecting on the predicate 
-    * reduces the number of records output by a query.
-    * For example if the reduction factor is 2, then the
-    * predicate cuts the size of the output in half.
+   /**
+    * Returns true if the predicate (with expressions from 2 different scans)
+    * evaluates to true in their respective scans.
+    * 
+    * @param s1 the first scan
+    * @param s2 the second scan
+    * @return true if the predicate is true in the scan
+    */
+   public boolean isSatisfied(Scan s1, Scan s2) {
+      for (Term t : terms)
+         if (!t.isSatisfied(s1, s2))
+            return false;
+      return true;
+   }
+
+   public boolean hasInequalityOpr() {
+      for (Term t : terms) {
+         if (t.isInequalityOpr()) {
+            return true;
+         }
+      }
+      return false;
+   }
+
+   /**
+    * Calculate the extent to which selecting on the predicate reduces the number
+    * of records output by a query. For example if the reduction factor is 2, then
+    * the predicate cuts the size of the output in half.
+    * 
     * @param p the query's plan
     * @return the integer reduction factor.
-    */ 
+    */
    public int reductionFactor(Plan p) {
       int factor = 1;
       for (Term t : terms)
@@ -65,6 +92,7 @@ public class Predicate {
 
    /**
     * Return the subpredicate that applies to the specified schema.
+    * 
     * @param sch the schema
     * @return the subpredicate applying to the schema
     */
@@ -80,12 +108,13 @@ public class Predicate {
    }
 
    /**
-    * Return the subpredicate consisting of terms that apply
-    * to the union of the two specified schemas, 
-    * but not to either schema separately.
+    * Return the subpredicate consisting of terms that apply to the union of the
+    * two specified schemas, but not to either schema separately.
+    * 
     * @param sch1 the first schema
     * @param sch2 the second schema
-    * @return the subpredicate whose terms apply to the union of the two schemas but not either schema separately.
+    * @return the subpredicate whose terms apply to the union of the two schemas
+    *         but not either schema separately.
     */
    public Predicate joinSubPred(Schema sch1, Schema sch2) {
       Predicate result = new Predicate();
@@ -93,9 +122,7 @@ public class Predicate {
       newsch.addAll(sch1);
       newsch.addAll(sch2);
       for (Term t : terms)
-         if (!t.appliesTo(sch1)  &&
-               !t.appliesTo(sch2) &&
-               t.appliesTo(newsch))
+         if (!t.appliesTo(sch1) && !t.appliesTo(sch2) && t.appliesTo(newsch))
             result.terms.add(t);
       if (result.terms.size() == 0)
          return null;
@@ -104,10 +131,10 @@ public class Predicate {
    }
 
    /**
-    * Determine if there is a term of the form "F=c"
-    * where F is the specified field and c is some constant.
-    * If so, the method returns that constant.
-    * If not, the method returns null.
+    * Determine if there is a term of the form "F=c" where F is the specified field
+    * and c is some constant. If so, the method returns that constant. If not, the
+    * method returns null.
+    * 
     * @param fldname the name of the field
     * @return either the constant or null
     */
@@ -121,10 +148,10 @@ public class Predicate {
    }
 
    /**
-    * Determine if there is a term of the form "F1=F2"
-    * where F1 is the specified field and F2 is another field.
-    * If so, the method returns the name of that field.
-    * If not, the method returns null.
+    * Determine if there is a term of the form "F1=F2" where F1 is the specified
+    * field and F2 is another field. If so, the method returns the name of that
+    * field. If not, the method returns null.
+    * 
     * @param fldname the name of the field
     * @return the name of the other field, or null
     */
@@ -139,7 +166,7 @@ public class Predicate {
 
    public String toString() {
       Iterator<Term> iter = terms.iterator();
-      if (!iter.hasNext()) 
+      if (!iter.hasNext())
          return "";
       String result = iter.next().toString();
       while (iter.hasNext())

--- a/src/simpledb/query/Predicate.java
+++ b/src/simpledb/query/Predicate.java
@@ -66,9 +66,9 @@ public class Predicate {
       return true;
    }
 
-   public boolean hasInequalityOpr() {
+   public boolean hasNonEqualOpr() {
       for (Term t : terms) {
-         if (t.isInequalityOpr()) {
+         if (t.isNonEqualOpr()) {
             return true;
          }
       }

--- a/src/simpledb/query/Term.java
+++ b/src/simpledb/query/Term.java
@@ -57,6 +57,13 @@ public class Term {
       return isTermSatisfied(lhsval, rhsval);
    }
 
+   /**
+    * Helper method evaluating lhs and rhs constants with the term's opr
+    * 
+    * @param lhsval lhs constant
+    * @param rhsval rhs constant
+    * @return
+    */
    private boolean isTermSatisfied(Constant lhsval, Constant rhsval) {
       String opval = op.getVal();
       switch (opval) {
@@ -78,8 +85,8 @@ public class Term {
       }
    }
 
-   public boolean isInequalityOpr() {
-      return op.isInequality();
+   public boolean isNonEqualOpr() {
+      return op.isNonEqualOpr();
    }
 
    /**

--- a/src/simpledb/query/Term.java
+++ b/src/simpledb/query/Term.java
@@ -5,62 +5,88 @@ import simpledb.record.*;
 
 /**
  * A term is a comparison between two expressions.
+ * 
  * @author Edward Sciore
- *
  */
 public class Term {
    private Expression lhs, rhs;
    private Operator op;
-   
+
    /**
-    * Create a new term that compares two expressions
-    * for equality.
-    * @param lhs  the LHS expression
-    * @param rhs  the RHS expression
+    * Create a new term that compares two expressions for equality.
+    * 
+    * @param lhs the LHS expression
+    * @param rhs the RHS expression
     */
    public Term(Expression lhs, Expression rhs, Operator op) {
       this.lhs = lhs;
       this.rhs = rhs;
       this.op = op;
    }
-   
+
    /**
-    * Return true if both of the term's expressions
-    * evaluate to the same constant,
+    * Return true if both of the term's expressions evaluate to the same constant,
     * with respect to the specified scan.
+    * 
     * @param s the scan
     * @return true if both expressions have the same value in the scan
     */
    public boolean isSatisfied(Scan s) {
       Constant lhsval = lhs.evaluate(s);
       Constant rhsval = rhs.evaluate(s);
+      return isTermSatisfied(lhsval, rhsval);
+   }
+
+   /**
+    * Return true if the term's expressions belong to 2 separate scans and evaluate
+    * to the same constant, in their respective scans.
+    * 
+    * @param s1 the 1st scan
+    * @param s2 the 2nd scan
+    * @return true if both expressions have the same value in the scan
+    */
+   public boolean isSatisfied(Scan s1, Scan s2) {
+      Constant lhsval, rhsval;
+      if (s1.hasField(lhs.asFieldName())) {
+         lhsval = lhs.evaluate(s1);
+         rhsval = rhs.evaluate(s2);
+      } else {
+         lhsval = lhs.evaluate(s2);
+         rhsval = rhs.evaluate(s1);
+      }
+      return isTermSatisfied(lhsval, rhsval);
+   }
+
+   private boolean isTermSatisfied(Constant lhsval, Constant rhsval) {
       String opval = op.getVal();
       switch (opval) {
-         case "=":
-            return rhsval.equals(lhsval);
-         case "!=":
-            return !rhsval.equals(lhsval);
-         case "<>":
-            return !rhsval.equals(lhsval);
-         case "<":
-            return lhsval.compareTo(rhsval) < 0;
-         case ">":
-            return lhsval.compareTo(rhsval) > 0;
-         case "<=":
-            return lhsval.compareTo(rhsval) <= 0;
-         case ">=":
-            return lhsval.compareTo(rhsval) >= 0;
-         default:
-            throw new RuntimeException("Unknown term: " + lhsval + " " + opval + " " + rhsval);
+      case "=":
+         return rhsval.equals(lhsval);
+      case "!=":
+      case "<>":
+         return !rhsval.equals(lhsval);
+      case "<":
+         return lhsval.compareTo(rhsval) < 0;
+      case ">":
+         return lhsval.compareTo(rhsval) > 0;
+      case "<=":
+         return lhsval.compareTo(rhsval) <= 0;
+      case ">=":
+         return lhsval.compareTo(rhsval) >= 0;
+      default:
+         throw new RuntimeException("Unknown term: " + lhsval + " " + opval + " " + rhsval);
       }
-
    }
-   
+
+   public boolean isInequalityOpr() {
+      return op.isInequality();
+   }
+
    /**
-    * Calculate the extent to which selecting on the term reduces 
-    * the number of records output by a query.
-    * For example if the reduction factor is 2, then the
+    * Calculate the extent to which selecting on the term reduces the number of
+    * records output by a query. For example if the reduction factor is 2, then the
     * term cuts the size of the output in half.
+    * 
     * @param p the query's plan
     * @return the integer reduction factor.
     */
@@ -69,8 +95,7 @@ public class Term {
       if (lhs.isFieldName() && rhs.isFieldName()) {
          lhsName = lhs.asFieldName();
          rhsName = rhs.asFieldName();
-         return Math.max(p.distinctValues(lhsName),
-                         p.distinctValues(rhsName));
+         return Math.max(p.distinctValues(lhsName), p.distinctValues(rhsName));
       }
       if (lhs.isFieldName()) {
          lhsName = lhs.asFieldName();
@@ -86,59 +111,51 @@ public class Term {
       else
          return Integer.MAX_VALUE;
    }
-   
+
    /**
-    * Determine if this term is of the form "F=c"
-    * where F is the specified field and c is some constant.
-    * If so, the method returns that constant.
-    * If not, the method returns null.
+    * Determine if this term is of the form "F=c" where F is the specified field
+    * and c is some constant. If so, the method returns that constant. If not, the
+    * method returns null.
+    * 
     * @param fldname the name of the field
     * @return either the constant or null
     */
    public Constant equatesWithConstant(String fldname) {
-      if (lhs.isFieldName() &&
-          lhs.asFieldName().equals(fldname) &&
-          !rhs.isFieldName())
+      if (lhs.isFieldName() && lhs.asFieldName().equals(fldname) && !rhs.isFieldName())
          return rhs.asConstant();
-      else if (rhs.isFieldName() &&
-               rhs.asFieldName().equals(fldname) &&
-               !lhs.isFieldName())
+      else if (rhs.isFieldName() && rhs.asFieldName().equals(fldname) && !lhs.isFieldName())
          return lhs.asConstant();
       else
          return null;
    }
-   
+
    /**
-    * Determine if this term is of the form "F1=F2"
-    * where F1 is the specified field and F2 is another field.
-    * If so, the method returns the name of that field.
-    * If not, the method returns null.
+    * Determine if this term is of the form "F1=F2" where F1 is the specified field
+    * and F2 is another field. If so, the method returns the name of that field. If
+    * not, the method returns null.
+    * 
     * @param fldname the name of the field
     * @return either the name of the other field, or null
     */
    public String equatesWithField(String fldname) {
-      if (lhs.isFieldName() &&
-          lhs.asFieldName().equals(fldname) &&
-          rhs.isFieldName())
+      if (lhs.isFieldName() && lhs.asFieldName().equals(fldname) && rhs.isFieldName())
          return rhs.asFieldName();
-      else if (rhs.isFieldName() &&
-               rhs.asFieldName().equals(fldname) &&
-               lhs.isFieldName())
+      else if (rhs.isFieldName() && rhs.asFieldName().equals(fldname) && lhs.isFieldName())
          return lhs.asFieldName();
       else
          return null;
    }
-   
+
    /**
-    * Return true if both of the term's expressions
-    * apply to the specified schema.
+    * Return true if both of the term's expressions apply to the specified schema.
+    * 
     * @param sch the schema
     * @return true if both expressions apply to the schema
     */
    public boolean appliesTo(Schema sch) {
       return lhs.appliesTo(sch) && rhs.appliesTo(sch);
    }
-   
+
    public String toString() {
       return lhs.toString() + op.getVal() + rhs.toString();
    }


### PR DESCRIPTION
## Changes in this PR

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change of an existing feature
- [ ] Refactor/Performance enhancements

## Overview

- Inequality join uses nested loop join which it is now supported for
- Nested loop join implementation checks all predicate before including it in the join
- Not-equal (ie. `!=`, `<>`) also default to nested loop join 

Test query 1:
```
select sid, studentid, eid from student, enroll where sid < studentid order by sid, studentid
```
Test query 2:
```
select sid, studentid, eid from student, enroll where studentid <= sid
```
Test query 3:
```
select sid, studentid, eid from student, enroll where studentid < sid and sid = eid
```
Test query 4:
```
select sid, studentid, eid from student, enroll where sid <= studentid order by sid, studentid, eid
```
Test query 5:
```
select sid, studentid, eid from student, enroll where sid <> studentid order by sid, studentid
```
Test query 6:
```
select sid, studentid, eid from student, enroll where studentid = sid
```