### PR TITLE
Fix: Operation throwing error when input table is empty

### DIFF
--- a/src/simpledb/index/query/IndexJoinScan.java
+++ b/src/simpledb/index/query/IndexJoinScan.java
@@ -17,6 +17,7 @@ public class IndexJoinScan implements Scan {
    private Index idx;
    private String joinfield;
    private TableScan rhs;  
+   private boolean hasmore1;
    
    /**
     * Creates an index join scan for the specified LHS scan and 
@@ -43,7 +44,7 @@ public class IndexJoinScan implements Scan {
     */
    public void beforeFirst() {
       lhs.beforeFirst();
-      lhs.next();
+      hasmore1 = lhs.next();
       resetIndex();
    }
    
@@ -56,6 +57,9 @@ public class IndexJoinScan implements Scan {
     * @see simpledb.query.Scan#next()
     */
    public boolean next() {
+      if (!hasmore1) {
+         return false;
+      }
       while (true) {
          if (idx.next()) {
             rhs.moveToRid(idx.getDataRid());

--- a/src/simpledb/materialize/MergeJoinScan.java
+++ b/src/simpledb/materialize/MergeJoinScan.java
@@ -11,6 +11,7 @@ public class MergeJoinScan implements Scan {
    private SortScan s2;
    private String fldname1, fldname2;
    private Constant joinval = null;
+   private boolean hasmore1;
    
    /**
     * Create a mergejoin scan for the two underlying sorted scans.
@@ -44,6 +45,7 @@ public class MergeJoinScan implements Scan {
     */
    public void beforeFirst() {
       s1.beforeFirst();
+      hasmore1 = s1.next();
       s2.beforeFirst();
    }
    
@@ -61,11 +63,14 @@ public class MergeJoinScan implements Scan {
     * @see simpledb.query.Scan#next()
     */
    public boolean next() {
+      System.out.println(hasmore1);
+      if (!hasmore1) {
+         return false;
+      }
       boolean hasmore2 = s2.next();
       if (hasmore2 && s2.getVal(fldname2).equals(joinval))
          return true;
       
-      boolean hasmore1 = s1.next();
       if (hasmore1 && s1.getVal(fldname1).equals(joinval)) {
          s2.restorePosition();
          return true;

--- a/src/simpledb/materialize/MergeJoinScan.java
+++ b/src/simpledb/materialize/MergeJoinScan.java
@@ -63,7 +63,6 @@ public class MergeJoinScan implements Scan {
     * @see simpledb.query.Scan#next()
     */
    public boolean next() {
-      System.out.println(hasmore1);
       if (!hasmore1) {
          return false;
       }

--- a/src/simpledb/materialize/SortPlan.java
+++ b/src/simpledb/materialize/SortPlan.java
@@ -92,10 +92,10 @@ public class SortPlan implements Plan {
    private List<TempTable> splitIntoRuns(Scan src) {
       List<TempTable> temps = new ArrayList<>();
       src.beforeFirst();
-      if (!src.next())
-         return temps;
       TempTable currenttemp = new TempTable(tx, sch);
       temps.add(currenttemp);
+      if (!src.next())
+         return temps;
       UpdateScan currentscan = currenttemp.open();
       while (copy(src, currentscan))
          if (comp.compare(src, currentscan) < 0) {

--- a/src/simpledb/query/ProductScan.java
+++ b/src/simpledb/query/ProductScan.java
@@ -7,6 +7,7 @@ package simpledb.query;
  */
 public class ProductScan implements Scan {
    private Scan s1, s2;
+   private boolean hasmore1;
 
    /**
     * Create a product scan having the two underlying scans.
@@ -28,7 +29,7 @@ public class ProductScan implements Scan {
     */
    public void beforeFirst() {
       s1.beforeFirst();
-      s1.next();
+      hasmore1 = s1.next();
       s2.beforeFirst();
    }
 
@@ -41,6 +42,9 @@ public class ProductScan implements Scan {
     * @see simpledb.query.Scan#next()
     */
    public boolean next() {
+      if (!hasmore1) {
+         return false;
+      }
       if (s2.next())
          return true;
       else {


### PR DESCRIPTION
## Changes in this PR

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change of an existing feature
- [ ] Refactor/Performance enhancements

## Overview

- Bug fix for operations on empty table 
- See #21 for sample queries
