### PR TITLE
Fix MergeJoinScan next logic

### DIFF
--- a/src/simpledb/materialize/MergeJoinScan.java
+++ b/src/simpledb/materialize/MergeJoinScan.java
@@ -11,7 +11,6 @@ public class MergeJoinScan implements Scan {
    private SortScan s2;
    private String fldname1, fldname2;
    private Constant joinval = null;
-   private boolean hasmore1;
    
    /**
     * Create a mergejoin scan for the two underlying sorted scans.

--- a/src/simpledb/materialize/MergeJoinScan.java
+++ b/src/simpledb/materialize/MergeJoinScan.java
@@ -45,7 +45,6 @@ public class MergeJoinScan implements Scan {
     */
    public void beforeFirst() {
       s1.beforeFirst();
-      hasmore1 = s1.next();
       s2.beforeFirst();
    }
    
@@ -63,13 +62,11 @@ public class MergeJoinScan implements Scan {
     * @see simpledb.query.Scan#next()
     */
    public boolean next() {
-      if (!hasmore1) {
-         return false;
-      }
       boolean hasmore2 = s2.next();
       if (hasmore2 && s2.getVal(fldname2).equals(joinval))
          return true;
       
+      boolean hasmore1 = s1.next();
       if (hasmore1 && s1.getVal(fldname1).equals(joinval)) {
          s2.restorePosition();
          return true;


### PR DESCRIPTION
## Changes in this PR

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change of an existing feature
- [ ] Refactor/Performance enhancements

## Overview
We were skipping the "next" call in the LHS table, causing the pointer on the LHS table to remain there permanently. This caused an infinite loop, which can be seen here https://github.com/don-tay/simpledb/issues/23
