### PR TITLE
Partition-based hash join

### DIFF
--- a/src/simpledb/materialize/HashJoinPlan.java
+++ b/src/simpledb/materialize/HashJoinPlan.java
@@ -1,7 +1,6 @@
 package simpledb.materialize;
 
 import simpledb.tx.Transaction;
-import simpledb.multibuffer.MultibufferProductPlan;
 import simpledb.plan.Plan;
 import simpledb.query.*;
 import simpledb.record.*;
@@ -52,7 +51,7 @@ public class HashJoinPlan implements Plan {
   public Scan open() {
     List<TempTable> b1 = hashToBuckets(p1, fldname1);
     List<TempTable> b2 = hashToBuckets(p2, fldname2);
-    return new HashJoinScan(tx, b1, b2, fldname1, fldname2);
+    return new HashJoinScan(b1, b2, fldname1, fldname2);
   }
 
   /**

--- a/src/simpledb/materialize/HashJoinPlan.java
+++ b/src/simpledb/materialize/HashJoinPlan.java
@@ -62,16 +62,18 @@ public class HashJoinPlan implements Plan {
    * Return the number of block acceses required to perform hashjoin on the
    * tables. Since a hashjoin can be preformed with a single pass through each
    * table, the method returns the sum of the block accesses of the materialized
-   * tables. Includes the one-time cost of materializing the records.
-   *
+   * tables. Page nested loop is then used to probe between the respective
+   * partitions. Hence, the cost is the sum of hashing, materializing and
+   * page-nested loop based probing (assuming partitions are evenly distributed.)
+   * 
    * @see simpledb.plan.Plan#blocksAccessed()
    */
-  // TODO: add formula
   public int blocksAccessed() {
-    int hashingCost = p1.blocksAccessed() + p2.blocksAccessed();
     Plan mp1 = new MaterializePlan(tx, p1);
     Plan mp2 = new MaterializePlan(tx, p2);
-    return hashingCost + mp1.blocksAccessed() + mp2.blocksAccessed();
+    int hashingCost = mp1.blocksAccessed() + mp2.blocksAccessed();
+    // ? Review formula
+    return hashingCost + p1.blocksAccessed() + (hashBucketCount * p2.blocksAccessed());
   }
 
   /**

--- a/src/simpledb/materialize/HashJoinPlan.java
+++ b/src/simpledb/materialize/HashJoinPlan.java
@@ -73,7 +73,7 @@ public class HashJoinPlan implements Plan {
     Plan mp2 = new MaterializePlan(tx, p2);
     int hashingCost = mp1.blocksAccessed() + mp2.blocksAccessed();
     // ? Review formula
-    return hashingCost + p1.blocksAccessed() + (hashBucketCount * p2.blocksAccessed());
+    return hashingCost + p1.blocksAccessed() + p2.blocksAccessed();
   }
 
   /**

--- a/src/simpledb/materialize/HashJoinPlan.java
+++ b/src/simpledb/materialize/HashJoinPlan.java
@@ -38,7 +38,6 @@ public class HashJoinPlan implements Plan {
     this.tx = tx;
     // hash into (B-1) buckets
     this.hashBucketCount = tx.availableBuffs() - 1;
-    System.out.println("Avail hash buckets: " + hashBucketCount);
 
     sch.addAll(p1.schema());
     sch.addAll(p2.schema());
@@ -51,9 +50,7 @@ public class HashJoinPlan implements Plan {
    * @see simpledb.plan.Plan#open()
    */
   public Scan open() {
-    System.out.println("Hashing 1st table...");
     List<TempTable> b1 = hashToBuckets(p1, fldname1);
-    System.out.println("Hashing 2nd table...");
     List<TempTable> b2 = hashToBuckets(p2, fldname2);
     return new HashJoinScan(tx, b1, b2, fldname1, fldname2);
   }
@@ -129,12 +126,9 @@ public class HashJoinPlan implements Plan {
       int idx = c.hashCode() % hashBucketCount;
       UpdateScan tblToInsert = tempTables.get(idx).open();
       tblToInsert.insert();
-      System.out.print("Inserted into table " + idx + ": ");
       for (String fldname : fields) {
-        System.out.print(s.getVal(fldname) + " ");
         tblToInsert.setVal(fldname, s.getVal(fldname));
       }
-      System.out.println();
       tblToInsert.close();
       hasmore = s.next();
     }

--- a/src/simpledb/materialize/HashJoinPlan.java
+++ b/src/simpledb/materialize/HashJoinPlan.java
@@ -38,6 +38,7 @@ public class HashJoinPlan implements Plan {
     this.tx = tx;
     // hash into (B-1) buckets
     this.hashBucketCount = tx.availableBuffs() - 1;
+    System.out.println("Avail hash buckets: " + hashBucketCount);
 
     sch.addAll(p1.schema());
     sch.addAll(p2.schema());
@@ -50,7 +51,9 @@ public class HashJoinPlan implements Plan {
    * @see simpledb.plan.Plan#open()
    */
   public Scan open() {
+    System.out.println("Hashing 1st table...");
     List<TempTable> b1 = hashToBuckets(p1, fldname1);
+    System.out.println("Hashing 2nd table...");
     List<TempTable> b2 = hashToBuckets(p2, fldname2);
     return new HashJoinScan(tx, b1, b2, fldname1, fldname2);
   }
@@ -124,9 +127,12 @@ public class HashJoinPlan implements Plan {
       int idx = c.hashCode() % hashBucketCount;
       UpdateScan tblToInsert = tempTables.get(idx).open();
       tblToInsert.insert();
+      System.out.print("Inserted into table " + idx + ": ");
       for (String fldname : fields) {
+        System.out.print(s.getVal(fldname) + " ");
         tblToInsert.setVal(fldname, s.getVal(fldname));
       }
+      System.out.println();
       tblToInsert.close();
     }
     s.close();

--- a/src/simpledb/materialize/HashJoinPlan.java
+++ b/src/simpledb/materialize/HashJoinPlan.java
@@ -117,12 +117,12 @@ public class HashJoinPlan implements Plan {
     List<TempTable> tempTables = initTempTables(p);
     List<String> fields = p.schema().fields();
     Scan s = p.open();
-    if (!s.next()) {
+    boolean hasmore = s.next();
+    if (!hasmore) {
       return tempTables;
     }
 
-    s.beforeFirst();
-    while (s.next()) {
+    while (hasmore) {
       Constant c = s.getVal(joinfield);
       int idx = c.hashCode() % hashBucketCount;
       UpdateScan tblToInsert = tempTables.get(idx).open();
@@ -134,6 +134,7 @@ public class HashJoinPlan implements Plan {
       }
       System.out.println();
       tblToInsert.close();
+      hasmore = s.next();
     }
     s.close();
     return tempTables;

--- a/src/simpledb/materialize/HashJoinScan.java
+++ b/src/simpledb/materialize/HashJoinScan.java
@@ -3,7 +3,6 @@ package simpledb.materialize;
 import java.util.List;
 
 import simpledb.query.*;
-import simpledb.tx.Transaction;
 
 /**
  * The Scan class for the <i>hashjoin</i> operator.
@@ -11,7 +10,6 @@ import simpledb.tx.Transaction;
  * @author Edward Sciore
  */
 public class HashJoinScan implements Scan {
-   private Transaction tx;
    private List<TempTable> b1, b2;
    private UpdateScan s1, s2;
    private String fldname1, fldname2;
@@ -25,10 +23,8 @@ public class HashJoinScan implements Scan {
     * @param b2       the RHS hashed buckets
     * @param fldname1 the LHS join field
     * @param fldname2 the RHS join field
-    * @param tx       the current transaction
     */
-   public HashJoinScan(Transaction tx, List<TempTable> b1, List<TempTable> b2, String fldname1, String fldname2) {
-      this.tx = tx;
+   public HashJoinScan(List<TempTable> b1, List<TempTable> b2, String fldname1, String fldname2) {
       this.b1 = b1;
       this.b2 = b2;
       this.fldname1 = fldname1;

--- a/src/simpledb/materialize/HashJoinScan.java
+++ b/src/simpledb/materialize/HashJoinScan.java
@@ -1,0 +1,144 @@
+package simpledb.materialize;
+
+import java.util.List;
+
+import simpledb.query.*;
+import simpledb.tx.Transaction;
+
+/**
+ * The Scan class for the <i>hashjoin</i> operator.
+ * 
+ * @author Edward Sciore
+ */
+public class HashJoinScan implements Scan {
+   private Transaction tx;
+   private List<TempTable> b1, b2;
+   private UpdateScan s1, s2;
+   private String fldname1, fldname2;
+   private int currIdx = 0;
+   private Constant joinval = null;
+
+   /**
+    * Create a hashjoin scan for the two underlying hash buckets.
+    * 
+    * @param b1       the LHS hashed buckets
+    * @param b2       the RHS hashed buckets
+    * @param fldname1 the LHS join field
+    * @param fldname2 the RHS join field
+    * @param tx       the current transaction
+    */
+   public HashJoinScan(Transaction tx, List<TempTable> b1, List<TempTable> b2, String fldname1, String fldname2) {
+      this.tx = tx;
+      this.b1 = b1;
+      this.b2 = b2;
+      this.fldname1 = fldname1;
+      this.fldname2 = fldname2;
+      beforeFirst();
+   }
+
+   /**
+    * Close the scan by closing the two underlying scans.
+    * 
+    * @see simpledb.query.Scan#close()
+    */
+   public void close() {
+      s1.close();
+      s2.close();
+   }
+
+   /**
+    * Position the scan before the first record, by positioning each underlying
+    * scan before their first records.
+    * 
+    * @see simpledb.query.Scan#beforeFirst()
+    */
+   public void beforeFirst() {
+      this.s1 = b1.get(currIdx).open();
+      this.s2 = b2.get(currIdx).open();
+      s1.beforeFirst();
+      s2.beforeFirst();
+   }
+
+   /**
+    * Move to the next record.
+    * <P>
+    * Start with first LHS record. Repeatedly move the RHS scan until a common join
+    * value is found. When RHS scan run out of records, move to the next LHS
+    * record. When LHS runs out of records, return false.
+    */
+   public boolean next() {
+      // TODO: handle temptable traversal. currently, only 1st temptable from b1 and
+      // b2 is scanned
+      while (true) {
+         boolean hasmore1 = true;
+         if (joinval == null) { // move lhs pointer when: 1. new scan 2. finished scanning rhs
+            hasmore1 = s1.next();
+         }
+         if (!hasmore1) {
+            return false;
+         }
+         boolean hasmore2 = s2.next();
+         joinval = s1.getVal(fldname1);
+
+         while (hasmore2) {
+            Constant v2 = s2.getVal(fldname2);
+            if (joinval.compareTo(v2) == 0) {
+               return true;
+            }
+
+            hasmore2 = s2.next();
+         }
+         // revert rhs to start if no more
+         joinval = null;
+         s2.beforeFirst();
+      }
+   }
+
+   /**
+    * Return the integer value of the specified field. The value is obtained from
+    * whichever scan contains the field.
+    * 
+    * @see simpledb.query.Scan#getInt(java.lang.String)
+    */
+   public int getInt(String fldname) {
+      if (s1.hasField(fldname))
+         return s1.getInt(fldname);
+      else
+         return s2.getInt(fldname);
+   }
+
+   /**
+    * Return the string value of the specified field. The value is obtained from
+    * whichever scan contains the field.
+    * 
+    * @see simpledb.query.Scan#getString(java.lang.String)
+    */
+   public String getString(String fldname) {
+      if (s1.hasField(fldname))
+         return s1.getString(fldname);
+      else
+         return s2.getString(fldname);
+   }
+
+   /**
+    * Return the value of the specified field. The value is obtained from whichever
+    * scan contains the field.
+    * 
+    * @see simpledb.query.Scan#getVal(java.lang.String)
+    */
+   public Constant getVal(String fldname) {
+      if (s1.hasField(fldname))
+         return s1.getVal(fldname);
+      else
+         return s2.getVal(fldname);
+   }
+
+   /**
+    * Return true if the specified field is in either of the underlying scans.
+    * 
+    * @see simpledb.query.Scan#hasField(java.lang.String)
+    */
+   public boolean hasField(String fldname) {
+      return s1.hasField(fldname) || s2.hasField(fldname);
+   }
+}

--- a/src/simpledb/materialize/HashJoinScan.java
+++ b/src/simpledb/materialize/HashJoinScan.java
@@ -16,7 +16,7 @@ public class HashJoinScan implements Scan {
    private UpdateScan s1, s2;
    private String fldname1, fldname2;
    private int currIdx = 0;
-   private Constant joinval;
+   private boolean hasJoinVal = false;
 
    /**
     * Create a hashjoin scan for the two underlying hash buckets.
@@ -69,11 +69,11 @@ public class HashJoinScan implements Scan {
    public boolean next() {
       boolean hasmore1 = true;
       while (true) {
-         if (joinval == null) { // move lhs pointer when: 1. new scan 2. finished scanning rhs
+         if (!hasJoinVal) { // move lhs pointer when: 1. new scan 2. finished scanning rhs
             hasmore1 = s1.next();
          }
          if (!hasmore1) { // if lhs has no more
-            joinval = null;
+            hasJoinVal = false;
             if (++currIdx >= b1.size()) { // end scan if no more temptables
                return false;
             }
@@ -87,14 +87,14 @@ public class HashJoinScan implements Scan {
          while (hasmore2) {
             Constant v2 = s2.getVal(fldname2);
             if (v1.compareTo(v2) == 0) {
-               joinval = s1.getVal(fldname1);
+               hasJoinVal = true;
                return true;
             }
 
             hasmore2 = s2.next();
          }
          // revert rhs to start if no more
-         joinval = null;
+         hasJoinVal = false;
          s2.beforeFirst();
       }
    }

--- a/src/simpledb/materialize/HashJoinScan.java
+++ b/src/simpledb/materialize/HashJoinScan.java
@@ -68,17 +68,16 @@ public class HashJoinScan implements Scan {
     */
    public boolean next() {
       boolean hasmore1 = true;
-      // TODO: bug in s1 traversal
       while (true) {
          if (joinval == null) { // move lhs pointer when: 1. new scan 2. finished scanning rhs
             hasmore1 = s1.next();
          }
          if (!hasmore1) { // if lhs has no more
-            close(); // close scan on current table
             joinval = null;
             if (++currIdx >= b1.size()) { // end scan if no more temptables
                return false;
             }
+            close(); // for non-last table, close scan on current table
             beforeFirst();
             return next(); // recursive call to scan new temptable
          }

--- a/src/simpledb/materialize/HashJoinScan.java
+++ b/src/simpledb/materialize/HashJoinScan.java
@@ -16,7 +16,7 @@ public class HashJoinScan implements Scan {
    private UpdateScan s1, s2;
    private String fldname1, fldname2;
    private int currIdx = 0;
-   private Constant joinval = null;
+   private Constant joinval;
 
    /**
     * Create a hashjoin scan for the two underlying hash buckets.
@@ -67,9 +67,9 @@ public class HashJoinScan implements Scan {
     * record. When LHS runs out of records, return false.
     */
    public boolean next() {
+      boolean hasmore1 = true;
       // TODO: bug in s1 traversal
       while (true) {
-         boolean hasmore1 = true;
          if (joinval == null) { // move lhs pointer when: 1. new scan 2. finished scanning rhs
             hasmore1 = s1.next();
          }

--- a/src/simpledb/materialize/HashJoinScan.java
+++ b/src/simpledb/materialize/HashJoinScan.java
@@ -67,22 +67,28 @@ public class HashJoinScan implements Scan {
     * record. When LHS runs out of records, return false.
     */
    public boolean next() {
-      // TODO: handle temptable traversal. currently, only 1st temptable from b1 and
-      // b2 is scanned
+      // TODO: bug in s1 traversal
       while (true) {
          boolean hasmore1 = true;
          if (joinval == null) { // move lhs pointer when: 1. new scan 2. finished scanning rhs
             hasmore1 = s1.next();
          }
-         if (!hasmore1) {
-            return false;
+         if (!hasmore1) { // if lhs has no more
+            close(); // close scan on current table
+            joinval = null;
+            if (++currIdx >= b1.size()) { // end scan if no more temptables
+               return false;
+            }
+            beforeFirst();
+            return next(); // recursive call to scan new temptable
          }
+         Constant v1 = s1.getVal(fldname1);
          boolean hasmore2 = s2.next();
-         joinval = s1.getVal(fldname1);
 
          while (hasmore2) {
             Constant v2 = s2.getVal(fldname2);
-            if (joinval.compareTo(v2) == 0) {
+            if (v1.compareTo(v2) == 0) {
+               joinval = s1.getVal(fldname1);
                return true;
             }
 

--- a/src/simpledb/opt/TablePlanner.java
+++ b/src/simpledb/opt/TablePlanner.java
@@ -115,21 +115,17 @@ class TablePlanner {
             String outerfield = mypred.equatesWithField(fldname);
             if (outerfield != null && currsch.hasField(outerfield)) {
                IndexInfo ii = indexes.get(fldname);
-               // idxJoinPlan = Optional.ofNullable(new IndexJoinPlan(current, myplan, ii,
-               // outerfield));
+               idxJoinPlan = Optional.ofNullable(new IndexJoinPlan(current, myplan, ii, outerfield));
             }
          }
          for (String fldname : myschema.fields()) {
             String outerfield = mypred.equatesWithField(fldname);
             if (outerfield != null) {
-               // mergeJoinPlan = Optional.ofNullable(new MergeJoinPlan(tx, current, myplan,
-               // outerfield, fldname));
+               mergeJoinPlan = Optional.ofNullable(new MergeJoinPlan(tx, current, myplan, outerfield, fldname));
             }
             // create hashjoin plan only if table B cannot fit in memory
             // otherwise, multibuffer product plan will suffice
-            if (outerfield != null
-            // && myplan.blocksAccessed() >= tx.availableBuffs()
-            ) {
+            if (outerfield != null && myplan.blocksAccessed() >= tx.availableBuffs()) {
                hashJoinPlan = Optional.ofNullable(new HashJoinPlan(tx, current, myplan, outerfield, fldname));
             }
          }

--- a/src/simpledb/opt/TablePlanner.java
+++ b/src/simpledb/opt/TablePlanner.java
@@ -122,10 +122,6 @@ class TablePlanner {
             String outerfield = mypred.equatesWithField(fldname);
             if (outerfield != null) {
                mergeJoinPlan = Optional.ofNullable(new MergeJoinPlan(tx, current, myplan, outerfield, fldname));
-            }
-            // create hashjoin plan only if table B cannot fit in memory
-            // otherwise, multibuffer product plan will suffice
-            if (outerfield != null && myplan.blocksAccessed() >= tx.availableBuffs()) {
                hashJoinPlan = Optional.ofNullable(new HashJoinPlan(tx, current, myplan, outerfield, fldname));
             }
          }

--- a/src/simpledb/opt/TablePlanner.java
+++ b/src/simpledb/opt/TablePlanner.java
@@ -115,17 +115,21 @@ class TablePlanner {
             String outerfield = mypred.equatesWithField(fldname);
             if (outerfield != null && currsch.hasField(outerfield)) {
                IndexInfo ii = indexes.get(fldname);
-               idxJoinPlan = Optional.ofNullable(new IndexJoinPlan(current, myplan, ii, outerfield));
+               // idxJoinPlan = Optional.ofNullable(new IndexJoinPlan(current, myplan, ii,
+               // outerfield));
             }
          }
          for (String fldname : myschema.fields()) {
             String outerfield = mypred.equatesWithField(fldname);
             if (outerfield != null) {
-               mergeJoinPlan = Optional.ofNullable(new MergeJoinPlan(tx, current, myplan, outerfield, fldname));
+               // mergeJoinPlan = Optional.ofNullable(new MergeJoinPlan(tx, current, myplan,
+               // outerfield, fldname));
             }
             // create hashjoin plan only if table B cannot fit in memory
             // otherwise, multibuffer product plan will suffice
-            if (outerfield != null && myplan.blocksAccessed() >= tx.availableBuffs()) {
+            if (outerfield != null
+            // && myplan.blocksAccessed() >= tx.availableBuffs()
+            ) {
                hashJoinPlan = Optional.ofNullable(new HashJoinPlan(tx, current, myplan, outerfield, fldname));
             }
          }

--- a/src/simpledb/plan/HashJoinPlan.java
+++ b/src/simpledb/plan/HashJoinPlan.java
@@ -1,0 +1,112 @@
+package simpledb.plan;
+
+import simpledb.tx.Transaction;
+import simpledb.materialize.MaterializePlan;
+import simpledb.materialize.MergeJoinScan;
+import simpledb.materialize.SortScan;
+import simpledb.plan.Plan;
+import simpledb.query.*;
+import simpledb.record.*;
+
+import java.util.*;
+
+/**
+ * The Plan class for the <i>hashjoin</i> operator.
+ * 
+ * @author Edward Sciore
+ */
+public class HashJoinPlan implements Plan {
+  private Plan p1, p2;
+  private String fldname1, fldname2;
+  private Schema sch = new Schema();
+  private Transaction tx;
+
+  /**
+   * Creates a hashjoin plan for the two specified queries. The RHS must be
+   * materialized after it is sorted, in order to deal with possible duplicates.
+   * 
+   * @param p1       the LHS query plan
+   * @param p2       the RHS query plan
+   * @param fldname1 the LHS join field
+   * @param fldname2 the RHS join field
+   * @param tx       the calling transaction
+   */
+  public HashJoinPlan(Transaction tx, Plan p1, Plan p2, String fldname1, String fldname2) {
+    this.p1 = p1;
+    this.p2 = p2;
+    this.fldname1 = fldname1;
+    this.fldname2 = fldname2;
+    this.tx = tx;
+
+    sch.addAll(p1.schema());
+    sch.addAll(p2.schema());
+  }
+
+  /**
+   * The method first sorts its two underlying scans on their join field. It then
+   * returns a hashjoin scan of the two sorted table scans.
+   * 
+   * @see simpledb.plan.Plan#open()
+   */
+  public Scan open() {
+    Scan s1 = p1.open();
+    // TODO: modify to a normal scan
+    SortScan s2 = (SortScan) p2.open();
+    return new MergeJoinScan(s1, s2, fldname1, fldname2);
+    // return new HashJoinScan(s1, s2, fldname1, fldname2);
+  }
+
+  /**
+   * Return the number of block acceses required to hashjoin the sorted tables.
+   * Since a hashjoin can be preformed with a single pass through each table, the
+   * method returns the sum of the block accesses of the materialized sorted
+   * tables. Includes the one-time cost of materializing and sorting the records.
+   * 
+   * @see simpledb.plan.Plan#blocksAccessed()
+   */
+  public int blocksAccessed() {
+    int hashingCost = p1.blocksAccessed() + p2.blocksAccessed();
+    Plan mp1 = new MaterializePlan(tx, p1);
+    Plan mp2 = new MaterializePlan(tx, p2);
+    return hashingCost + mp1.blocksAccessed() + mp2.blocksAccessed();
+  }
+
+  /**
+   * Return the number of records in the join. Assuming uniform distribution, the
+   * formula is:
+   * 
+   * <pre>
+   *  R(join(p1,p2)) = R(p1)*R(p2)/max{V(p1,F1),V(p2,F2)}
+   * </pre>
+   * 
+   * @see simpledb.plan.Plan#recordsOutput()
+   */
+  public int recordsOutput() {
+    int maxvals = Math.max(p1.distinctValues(fldname1), p2.distinctValues(fldname2));
+    return (p1.recordsOutput() * p2.recordsOutput()) / maxvals;
+  }
+
+  /**
+   * Estimate the distinct number of field values in the join. Since the join does
+   * not increase or decrease field values, the estimate is the same as in the
+   * appropriate underlying query.
+   * 
+   * @see simpledb.plan.Plan#distinctValues(java.lang.String)
+   */
+  public int distinctValues(String fldname) {
+    if (p1.schema().hasField(fldname))
+      return p1.distinctValues(fldname);
+    else
+      return p2.distinctValues(fldname);
+  }
+
+  /**
+   * Return the schema of the join, which is the union of the schemas of the
+   * underlying queries.
+   * 
+   * @see simpledb.plan.Plan#schema()
+   */
+  public Schema schema() {
+    return sch;
+  }
+}

--- a/src/test/SimpleIJ.java
+++ b/src/test/SimpleIJ.java
@@ -84,7 +84,7 @@ public class SimpleIJ {
 			}
 			tx.commit();
 		} catch (Exception e) {
-			System.out.println("SQL Exception: " + e.toString());
+			e.printStackTrace();
 			tx.rollback();
 		}
 	}
@@ -96,7 +96,6 @@ public class SimpleIJ {
 			System.out.println(numRecordsUpdated + " records processed");
 		} catch (Exception e) {
 			e.printStackTrace();
-			System.err.println("Exception: " + e.toString());
 			tx.rollback();
 		}
 	}

--- a/src/test/SimpleIJ.java
+++ b/src/test/SimpleIJ.java
@@ -94,7 +94,8 @@ public class SimpleIJ {
 			tx.commit();
 			System.out.println(numRecordsUpdated + " records processed");
 		} catch (Exception e) {
-			System.out.println("Exception: " + e.toString());
+			e.printStackTrace();
+			System.err.println("Exception: " + e.toString());
 		}
 	}
 }


### PR DESCRIPTION
## Changes in this PR

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change of an existing feature
- [ ] Refactor/Performance enhancements

## Overview

- Partition-based hash join. Implementation partitions both table A and B into `(B-1)` partitions. It then uses a page-based nested loop to join the tables in the respective partitions.
