### PR TITLE
Fix/hashjoin overflow

### DIFF
--- a/src/simpledb/materialize/HashJoinPlan.java
+++ b/src/simpledb/materialize/HashJoinPlan.java
@@ -1,6 +1,7 @@
 package simpledb.materialize;
 
 import simpledb.tx.Transaction;
+import simpledb.multibuffer.BufferNeeds;
 import simpledb.plan.Plan;
 import simpledb.query.*;
 import simpledb.record.*;
@@ -36,7 +37,8 @@ public class HashJoinPlan implements Plan {
     this.fldname2 = fldname2;
     this.tx = tx;
     // hash into (B-1) buckets
-    this.hashBucketCount = tx.availableBuffs() - 1;
+    this.hashBucketCount = BufferNeeds.bestFactor(tx.availableBuffs(),
+        Math.max(p1.blocksAccessed(), p2.blocksAccessed()));
 
     sch.addAll(p1.schema());
     sch.addAll(p2.schema());

--- a/src/simpledb/materialize/HashJoinScan.java
+++ b/src/simpledb/materialize/HashJoinScan.java
@@ -53,6 +53,7 @@ public class HashJoinScan implements Scan {
       this.s2 = b2.get(currIdx).open();
       s1.beforeFirst();
       s2.beforeFirst();
+      hasJoinVal = false;
    }
 
    /**


### PR DESCRIPTION
## Changes in this PR

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change of an existing feature
- [ ] Refactor/Performance enhancements

## Overview

- Resolve beforeFirst logic bug in hashjoinscan by setting `hasJoinVal` to `false` when called
- Resolve buffer overflow caused by creating too many hash buckets in hashjoin. Fewer hash buckets are created now using `BufferNeeds.bestFactor` method.

Following query which used to throw `BufferAbortException` now works:
```
select sid,sname,eid,sectid from student, enroll, section where sid=studentid and sectionid=sectid order by sid
```

Following query which threw `IndexOutOfBoundException` (due to `beforeFirst` logic) now works:
```
select distinct prof from student, enroll, section where sid=studentid and sectionid=sectid
```