### PR TITLE
Handle sort plan creation in query planner depending on GROUP BY/DISTINCT

### DIFF
--- a/src/simpledb/opt/HeuristicQueryPlanner.java
+++ b/src/simpledb/opt/HeuristicQueryPlanner.java
@@ -47,23 +47,22 @@ public class HeuristicQueryPlanner implements QueryPlanner {
             currentplan = getLowestProductPlan(currentplan);
       }
 
-      // Step 4. Sort on the records
-      if (!data.sortfields().isEmpty()) {
-         currentplan = new SortPlan(tx, currentplan, data.sortfields());
-      }
-
-
-      // Step 5: Group By And/Or aggregate
+      // Step 4: Group By And/Or aggregate
       if (!data.groupbyfields().isEmpty() || !data.aggregateFuncs().isEmpty()) {
          currentplan = new GroupByPlan(tx, currentplan, data.groupbyfields(), data.aggregateFuncs());
       }
-   
+
       // Step 5: Project on the field names and return
       currentplan = new ProjectPlan(currentplan, data.fields());
-      
+
       // Step 6: Remove duplicate records
       if (data.isDistinct()) {
          currentplan = new DistinctPlan(tx, currentplan, data.fields());
+      }
+
+      // Step 7. Sort on the records
+      if (!data.sortfields().isEmpty()) {
+         currentplan = new SortPlan(tx, currentplan, data.sortfields());
       }
 
       return currentplan;

--- a/src/simpledb/opt/HeuristicQueryPlanner.java
+++ b/src/simpledb/opt/HeuristicQueryPlanner.java
@@ -52,17 +52,17 @@ public class HeuristicQueryPlanner implements QueryPlanner {
          currentplan = new GroupByPlan(tx, currentplan, data.groupbyfields(), data.aggregateFuncs());
       }
 
-      // Step 5: Project on the field names and return
-      currentplan = new ProjectPlan(currentplan, data.fields());
-
-      // Step 6: Remove duplicate records
-      if (data.isDistinct()) {
-         currentplan = new DistinctPlan(tx, currentplan, data.fields());
-      }
-
-      // Step 7. Sort on the records
+      // Step 5. Sort on the records
       if (!data.sortfields().isEmpty()) {
          currentplan = new SortPlan(tx, currentplan, data.sortfields());
+      }
+
+      // Step 6: Project on the field names and return
+      currentplan = new ProjectPlan(currentplan, data.fields());
+
+      // Step 7: Remove duplicate records
+      if (data.isDistinct()) {
+         currentplan = new DistinctPlan(tx, currentplan, data.fields());
       }
 
       return currentplan;

--- a/src/simpledb/opt/HeuristicQueryPlanner.java
+++ b/src/simpledb/opt/HeuristicQueryPlanner.java
@@ -60,7 +60,7 @@ public class HeuristicQueryPlanner implements QueryPlanner {
       // Step 6: Project on the field names and return
       currentplan = new ProjectPlan(currentplan, data.fields());
 
-      // Step 7: Remove duplicate records
+      // Step 7: Remove duplicate records and sort (iff distinct plan is created)
       if (data.isDistinct() && !data.sortfields().isEmpty()) {
          currentplan = new DistinctPlan(tx, currentplan, data.fields());
          currentplan = new SortPlan(tx, currentplan, data.sortfields());

--- a/src/simpledb/opt/HeuristicQueryPlanner.java
+++ b/src/simpledb/opt/HeuristicQueryPlanner.java
@@ -52,8 +52,8 @@ public class HeuristicQueryPlanner implements QueryPlanner {
          currentplan = new GroupByPlan(tx, currentplan, data.groupbyfields(), data.aggregateFuncs());
       }
 
-      // Step 5. Sort on the records
-      if (!data.sortfields().isEmpty()) {
+      // Step 5. Sort on the records (iff distinct plan is not created)
+      if (!data.isDistinct() && !data.sortfields().isEmpty()) {
          currentplan = new SortPlan(tx, currentplan, data.sortfields());
       }
 
@@ -61,8 +61,9 @@ public class HeuristicQueryPlanner implements QueryPlanner {
       currentplan = new ProjectPlan(currentplan, data.fields());
 
       // Step 7: Remove duplicate records
-      if (data.isDistinct()) {
+      if (data.isDistinct() && !data.sortfields().isEmpty()) {
          currentplan = new DistinctPlan(tx, currentplan, data.fields());
+         currentplan = new SortPlan(tx, currentplan, data.sortfields());
       }
 
       return currentplan;


### PR DESCRIPTION
## Changes in this PR

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change of an existing feature
- [ ] Refactor/Performance enhancements

## Overview

- Handle sort plan creation in table planner depending if group by / distinct is present (see comments below for more info)

This fixes following query (in #35):
```
select dname,count(sid) from student, dept where majorid=did group by dname order by dname desc
```
```
 dname countofsid
-----------------
 math         4
drama         6
compsci         7
```
