### PR TITLE
Fix wrong result when using non-equality predicate on idx fields

### DIFF
--- a/src/simpledb/opt/TablePlanner.java
+++ b/src/simpledb/opt/TablePlanner.java
@@ -88,10 +88,10 @@ class TablePlanner {
 
    private Plan makeIndexSelect() {
       for (String fldname : indexes.keySet()) {
-         // TODO: return null if term involved is a non-equal (ie. all inequality + not
-         // equals) operator
-         Constant val = mypred.equatesWithConstant(fldname);
-         if (val != null) {
+         Term term = mypred.equatesWithConstant(fldname);
+         // create idx iff term has equality ('=') operator
+         if (term != null && !term.isNonEqualOpr()) {
+            Constant val = term.equatesWithConstant(fldname);
             IndexInfo ii = indexes.get(fldname);
             System.out.println("index on " + fldname + " used");
             return new IndexSelectPlan(myplan, ii, val);

--- a/src/simpledb/opt/TablePlanner.java
+++ b/src/simpledb/opt/TablePlanner.java
@@ -88,6 +88,8 @@ class TablePlanner {
 
    private Plan makeIndexSelect() {
       for (String fldname : indexes.keySet()) {
+         // TODO: return null if term involved is a non-equal (ie. all inequality + not
+         // equals) operator
          Constant val = mypred.equatesWithConstant(fldname);
          if (val != null) {
             IndexInfo ii = indexes.get(fldname);

--- a/src/simpledb/query/Predicate.java
+++ b/src/simpledb/query/Predicate.java
@@ -132,17 +132,17 @@ public class Predicate {
 
    /**
     * Determine if there is a term of the form "F=c" where F is the specified field
-    * and c is some constant. If so, the method returns that constant. If not, the
-    * method returns null.
+    * and c is some constant. If so, the method returns that Term (ie. Constant and
+    * Operator). If not, the method returns null.
     * 
     * @param fldname the name of the field
-    * @return either the constant or null
+    * @return either the term or null
     */
-   public Constant equatesWithConstant(String fldname) {
+   public Term equatesWithConstant(String fldname) {
       for (Term t : terms) {
          Constant c = t.equatesWithConstant(fldname);
          if (c != null)
-            return c;
+            return t;
       }
       return null;
    }


### PR DESCRIPTION
fixes #33 

## Changes in this PR

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change of an existing feature
- [ ] Refactor/Performance enhancements

## Overview

- Default to a sequential scan when non-equi pred used
