### PR TITLE
Chore/refactor joinplan

### DIFF
--- a/src/simpledb/index/planner/IndexJoinPlan.java
+++ b/src/simpledb/index/planner/IndexJoinPlan.java
@@ -3,6 +3,7 @@ package simpledb.index.planner;
 import simpledb.record.*;
 import simpledb.query.*;
 import simpledb.metadata.IndexInfo;
+import simpledb.plan.JoinPlan;
 import simpledb.plan.Plan;
 import simpledb.index.Index;
 import simpledb.index.query.IndexJoinScan;
@@ -11,7 +12,7 @@ import simpledb.index.query.IndexJoinScan;
   * relational algebra operator.
   * @author Edward Sciore
   */
-public class IndexJoinPlan implements Plan {
+public class IndexJoinPlan implements JoinPlan {
    private Plan p1, p2;
    private IndexInfo ii;
    private String joinfield;
@@ -87,5 +88,10 @@ public class IndexJoinPlan implements Plan {
     */
    public Schema schema() {
       return sch;
+   }
+
+   public void printJoinCost() {
+      System.out.println(
+            "Running index join on " + joinfield + " and " + ii.getFieldName() + " (cost=" + blocksAccessed() + ")");
    }
 }

--- a/src/simpledb/index/planner/IndexJoinPlan.java
+++ b/src/simpledb/index/planner/IndexJoinPlan.java
@@ -92,6 +92,6 @@ public class IndexJoinPlan implements JoinPlan {
 
    public void printJoinCost() {
       System.out.println(
-            "Running index join on " + joinfield + " and " + ii.getFieldName() + " (cost=" + blocksAccessed() + ")");
+            "Running index join on fields " + joinfield + " and " + ii.getFieldName() + " (cost=" + blocksAccessed() + ")");
    }
 }

--- a/src/simpledb/materialize/HashJoinPlan.java
+++ b/src/simpledb/materialize/HashJoinPlan.java
@@ -147,6 +147,6 @@ public class HashJoinPlan implements JoinPlan {
   }
 
   public void printJoinCost() {
-    System.out.println("Running hash join on " + fldname1 + " and " + fldname2 + " (cost=" + blocksAccessed() + ")");
+    System.out.println("Running hash join on fields " + fldname1 + " and " + fldname2 + " (cost=" + blocksAccessed() + ")");
   }
 }

--- a/src/simpledb/materialize/HashJoinPlan.java
+++ b/src/simpledb/materialize/HashJoinPlan.java
@@ -2,6 +2,7 @@ package simpledb.materialize;
 
 import simpledb.tx.Transaction;
 import simpledb.multibuffer.BufferNeeds;
+import simpledb.plan.JoinPlan;
 import simpledb.plan.Plan;
 import simpledb.query.*;
 import simpledb.record.*;
@@ -13,7 +14,7 @@ import java.util.*;
  * 
  * @author Edward Sciore
  */
-public class HashJoinPlan implements Plan {
+public class HashJoinPlan implements JoinPlan {
   private Plan p1, p2;
   private String fldname1, fldname2;
   private Schema sch = new Schema();
@@ -143,5 +144,9 @@ public class HashJoinPlan implements Plan {
       tempTables.add(new TempTable(tx, p.schema()));
     }
     return tempTables;
+  }
+
+  public void printJoinCost() {
+    System.out.println("Running hash join on " + fldname1 + " and " + fldname2 + " (cost=" + blocksAccessed() + ")");
   }
 }

--- a/src/simpledb/materialize/MergeJoinPlan.java
+++ b/src/simpledb/materialize/MergeJoinPlan.java
@@ -111,6 +111,6 @@ public class MergeJoinPlan implements JoinPlan {
 
    public void printJoinCost() {
       System.out.println(
-            "Running sort merge join on " + fldname1 + " and " + fldname2 + " (cost=" + blocksAccessed() + ")");
+            "Running sort merge join on fields " + fldname1 + " and " + fldname2 + " (cost=" + blocksAccessed() + ")");
    }
 }

--- a/src/simpledb/materialize/MergeJoinPlan.java
+++ b/src/simpledb/materialize/MergeJoinPlan.java
@@ -1,6 +1,7 @@
 package simpledb.materialize;
 
 import simpledb.tx.Transaction;
+import simpledb.plan.JoinPlan;
 import simpledb.plan.Plan;
 import simpledb.query.*;
 import simpledb.record.*;
@@ -12,7 +13,7 @@ import java.util.*;
  * 
  * @author Edward Sciore
  */
-public class MergeJoinPlan implements Plan {
+public class MergeJoinPlan implements JoinPlan {
    private Plan p1, p2;
    private String fldname1, fldname2;
    private Schema sch = new Schema();
@@ -58,8 +59,7 @@ public class MergeJoinPlan implements Plan {
     * Return the number of block acceses required to mergejoin the sorted tables.
     * Since a mergejoin can be preformed with a single pass through each table, the
     * method returns the sum of the block accesses of the materialized sorted
-    * tables. Includes the one-time cost of materializing and
-    * sorting the records.
+    * tables. Includes the one-time cost of materializing and sorting the records.
     * 
     * @see simpledb.plan.Plan#blocksAccessed()
     */
@@ -107,5 +107,10 @@ public class MergeJoinPlan implements Plan {
     */
    public Schema schema() {
       return sch;
+   }
+
+   public void printJoinCost() {
+      System.out.println(
+            "Running sort merge join on " + fldname1 + " and " + fldname2 + " (cost=" + blocksAccessed() + ")");
    }
 }

--- a/src/simpledb/metadata/IndexInfo.java
+++ b/src/simpledb/metadata/IndexInfo.java
@@ -95,6 +95,10 @@ public class IndexInfo {
       return fldname.equals(fname) ? 1 : si.distinctValues(fldname);
    }
 
+   public String getFieldName() {
+      return fldname;
+   }
+
    /**
     * Return the layout of the index records. The schema consists of the dataRID
     * (which is represented as two integers, the block number and the record ID)

--- a/src/simpledb/plan/JoinPlan.java
+++ b/src/simpledb/plan/JoinPlan.java
@@ -1,0 +1,5 @@
+package simpledb.plan;
+
+public interface JoinPlan extends Plan {
+  public void printJoinCost();
+}

--- a/src/simpledb/plan/NestedLoopsJoinPlan.java
+++ b/src/simpledb/plan/NestedLoopsJoinPlan.java
@@ -84,6 +84,6 @@ public class NestedLoopsJoinPlan implements JoinPlan {
    }
 
    public void printJoinCost() {
-      System.out.println("Running nested loop join on " + joinpred.toString() + " (cost=" + blocksAccessed() + ")");
+      System.out.println("Running nested loop join on fields " + joinpred.toString() + " (cost=" + blocksAccessed() + ")");
    }
 }

--- a/src/simpledb/plan/NestedLoopsJoinPlan.java
+++ b/src/simpledb/plan/NestedLoopsJoinPlan.java
@@ -5,7 +5,7 @@ import simpledb.query.Predicate;
 import simpledb.query.Scan;
 import simpledb.record.Schema;
 
-public class NestedLoopsJoinPlan implements Plan {
+public class NestedLoopsJoinPlan implements JoinPlan {
    private Plan p1, p2;
    private Predicate joinpred;
    private Schema sch = new Schema();
@@ -81,5 +81,9 @@ public class NestedLoopsJoinPlan implements Plan {
     */
    public Schema schema() {
       return sch;
+   }
+
+   public void printJoinCost() {
+      System.out.println("Running nested loop join on " + joinpred.toString() + " (cost=" + blocksAccessed() + ")");
    }
 }


### PR DESCRIPTION
## Changes in this PR

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change of an existing feature
- [x] Refactor/Performance enhancements

## Overview

- Refactor join plan
- Join plans prints their join implementation and the fields being joined
```
SQL> select sid,sname,dname,title,prof,grade from student,dept,course,section,enroll where sid=studentid and sectionid=sectid and courseid=cid and deptid=did and majorid=did
Running Sequential Scan on student (cost=2 width=4)
Running Sequential Scan on dept (cost=1 width=2)
Running Sequential Scan on course (cost=1 width=3)
Running Sequential Scan on section (cost=1 width=4)
Running Sequential Scan on enroll (cost=1 width=4)
Running hash join on did and majorid (cost=6)
Running sort merge join on did and deptid (cost=6)
Running sort merge join on sectid and sectionid (cost=6)
Running sort merge join on cid and courseid (cost=3)
Running sort merge join on sectid and sectionid (cost=3)
 sid sname dname title prof grade
---------------------------------
  1  joecompscidb systemsturing    A
  4  sue mathcalculusnewton    B
  2  amy mathcalculuseinstein   B+
```
