### PR TITLE
Fix wrong pred evaluated with wrong plan

### DIFF
--- a/src/simpledb/opt/TablePlanner.java
+++ b/src/simpledb/opt/TablePlanner.java
@@ -120,14 +120,14 @@ class TablePlanner {
       // "<>", "<=", "<"
       if (!joinpred.hasNonEqualOpr()) {
          for (String fldname : indexes.keySet()) {
-            String outerfield = mypred.equatesWithField(fldname);
+            String outerfield = joinpred.equatesWithField(fldname);
             if (outerfield != null && currsch.hasField(outerfield)) {
                IndexInfo ii = indexes.get(fldname);
                idxJoinPlan = Optional.ofNullable(new IndexJoinPlan(current, myplan, ii, outerfield));
             }
          }
          for (String fldname : myschema.fields()) {
-            String outerfield = mypred.equatesWithField(fldname);
+            String outerfield = joinpred.equatesWithField(fldname);
             if (outerfield != null) {
                mergeJoinPlan = Optional.ofNullable(new MergeJoinPlan(tx, current, myplan, outerfield, fldname));
                hashJoinPlan = Optional.ofNullable(new HashJoinPlan(tx, current, myplan, outerfield, fldname));


### PR DESCRIPTION
## Changes in this PR

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change of an existing feature
- [ ] Refactor/Performance enhancements

## Overview

- Predicate not found in plan being used in forming joins
- To fix this, only predicates found in table have their joins attempted on
- Otherwise, default to using cross product followed by selectscan. Hence, correctness is guaranteed.

This fixes the following query when avg num of rows in table is 50 (in #47):
```
select sid,sname,eid,sectid from student, enroll, section where sid=studentid and sectionid=sectid
```
