### PR TITLE
Fix wrong pred used by planner in join

### DIFF
--- a/src/simpledb/materialize/HashJoinPlan.java
+++ b/src/simpledb/materialize/HashJoinPlan.java
@@ -149,6 +149,7 @@ public class HashJoinPlan implements JoinPlan {
   }
 
   public void printJoinCost() {
-    System.out.println("Running hash join on fields " + fldname1 + " and " + fldname2 + " (cost=" + blocksAccessed() + ")");
+    System.out
+        .println("Running hash join on fields " + fldname1 + " and " + fldname2 + " (cost=" + blocksAccessed() + ")");
   }
 }

--- a/src/simpledb/opt/TablePlanner.java
+++ b/src/simpledb/opt/TablePlanner.java
@@ -120,15 +120,15 @@ class TablePlanner {
       // "<>", "<=", "<"
       if (!joinpred.hasNonEqualOpr()) {
          for (String fldname : indexes.keySet()) {
-            String outerfield = joinpred.equatesWithField(fldname);
+            String outerfield = mypred.equatesWithField(fldname);
             if (outerfield != null && currsch.hasField(outerfield)) {
                IndexInfo ii = indexes.get(fldname);
                idxJoinPlan = Optional.ofNullable(new IndexJoinPlan(current, myplan, ii, outerfield));
             }
          }
          for (String fldname : myschema.fields()) {
-            String outerfield = joinpred.equatesWithField(fldname);
-            if (outerfield != null) {
+            String outerfield = mypred.equatesWithField(fldname);
+            if (outerfield != null && currsch.hasField(outerfield)) {
                mergeJoinPlan = Optional.ofNullable(new MergeJoinPlan(tx, current, myplan, outerfield, fldname));
                hashJoinPlan = Optional.ofNullable(new HashJoinPlan(tx, current, myplan, outerfield, fldname));
             }


### PR DESCRIPTION
## Changes in this PR

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change of an existing feature
- [ ] Refactor/Performance enhancements

## Overview

- Fix wrong pred used by table planner

Queries tested:
```
select dname,count(sid) from student, dept where majorid=did group by dname order by dname desc
```
```
select sid,sname,eid,sectid from student, enroll, section where sid=studentid and sectionid=sectid
```
```
select sid,sname,dname,title,grade from student,dept,course,enroll where sid=studentid and deptid=did and majorid=did
```

Still erroring queries
- Distinct and group by queries with 3 tables or more (#39)
