### PR TITLE
Update Sorting Merge Cost

### DIFF
--- a/src/simpledb/materialize/SortPlan.java
+++ b/src/simpledb/materialize/SortPlan.java
@@ -55,8 +55,9 @@ public class SortPlan implements Plan {
       Plan mp = new MaterializePlan(tx, p); // not opened; just for analysis
       int scanLength = mp.blocksAccessed();
       // number of passes = Math.ceil(log_{B-1}^{Math.ceil(Num pages / Num buffers)})
-      int sortedRuns = (int) Math.ceil((float) scanLength / tx.availableBuffs());
-      int mergePasses = (int) Math.ceil(SortPlan.customLog(tx.availableBuffs() - 1, (int)sortedRuns));
+      int buffersUsed = 3; // only 3 used including output buffer instead of tx.availableBuffs
+      int sortedRuns = (int) Math.ceil((float) scanLength / buffersUsed);
+      int mergePasses = (int) Math.ceil(SortPlan.customLog(buffersUsed - 1, (int) sortedRuns));
       if (scanLength == 0) {
          // In case there is no table to sort on, there is 0 cost.
          return 0;

--- a/src/simpledb/multibuffer/MultibufferProductPlan.java
+++ b/src/simpledb/multibuffer/MultibufferProductPlan.java
@@ -98,6 +98,10 @@ public class MultibufferProductPlan implements Plan {
       return schema;
    }
 
+   public void printJoinCost() {
+      System.out.println("Running multi buffer cross product (cost=" + blocksAccessed() + ")");
+   }
+
    private TempTable copyRecordsFrom(Plan p) {
       Scan   src = p.open(); 
       Schema sch = p.schema();

--- a/src/simpledb/multibuffer/MultibufferProductPlan.java
+++ b/src/simpledb/multibuffer/MultibufferProductPlan.java
@@ -98,10 +98,6 @@ public class MultibufferProductPlan implements Plan {
       return schema;
    }
 
-   public void printJoinCost() {
-      System.out.println("Running multi buffer cross product (cost=" + blocksAccessed() + ")");
-   }
-
    private TempTable copyRecordsFrom(Plan p) {
       Scan   src = p.open(); 
       Schema sch = p.schema();

--- a/src/simpledb/opt/TablePlanner.java
+++ b/src/simpledb/opt/TablePlanner.java
@@ -165,6 +165,7 @@ class TablePlanner {
 
    private Plan makeProductJoin(Plan current, Schema currsch) {
       Plan p = makeProductPlan(current);
+      System.out.println("Running cross product (cost=" + p.blocksAccessed() + ")");
       return addJoinPred(p, currsch);
    }
 


### PR DESCRIPTION
## Changes in this PR

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change of an existing feature
- [ ] Refactor/Performance enhancements

## Overview

- Update buffer used for sorting to 3
- For hash join BufferNeeds.bestFactor() method already ensures that we use buffers within the limit so I did not change the cost for hash join
